### PR TITLE
fix 签名异常

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fanfou-sdk",
-  "version": "4.0.5",
+  "name": "rsshub-fanfou-sdk",
+  "version": "4.1.5",
   "description": "Fanfou SDK for Node.js",
   "main": "src/index.js",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ class Fanfou {
 			oauthTokenSecret: this.oauthTokenSecret = '',
 			username: this.username = '',
 			password: this.password = '',
-			protocol: this.protocol = 'http:',
+			protocol: this.protocol = 'https:',
+			signProtocol: this.signProtocol = 'http:',
 			apiDomain: this.apiDomain = 'api.fanfou.com',
 			oauthDomain: this.oauthDomain = 'fanfou.com',
 			hooks: this.hooks = {}
@@ -80,8 +81,9 @@ class Fanfou {
 	async get(uri, params) {
 		const query = queryString.stringify(params);
 		const url = `${this.apiEndPoint}${uri}.json${query ? `?${query}` : ''}`;
+		const signUrl = `${this.signProtocol}//${this.apiDomain}${uri}.json${query ? `?${query}` : ''}`;
 		const token = {key: this.oauthToken, secret: this.oauthTokenSecret};
-		const {Authorization} = this.o.toHeader(this.o.authorize({url, method: 'GET'}, token));
+		const {Authorization} = this.o.toHeader(this.o.authorize({url: signUrl, method: 'GET'}, token));
 		try {
 			const {body} = await got.get(url, {
 				headers: {
@@ -99,9 +101,14 @@ class Fanfou {
 
 	async post(uri, params) {
 		const url = `${this.apiEndPoint}${uri}.json`;
+		const signUrl = `${this.signProtocol}//${this.apiDomain}${uri}.json${query ? `?${query}` : ''}`;
 		const token = {key: this.oauthToken, secret: this.oauthTokenSecret};
 		const isUpload = ['/photos/upload', '/account/update_profile_image'].includes(uri);
-		const {Authorization} = this.o.toHeader(this.o.authorize({url, method: 'POST', data: isUpload ? null : params}, token));
+		const {Authorization} = this.o.toHeader(this.o.authorize({
+			url: signUrl,
+			method: 'POST',
+			data: isUpload ? null : params
+		}, token));
 		let form = null;
 		const headers = {Authorization, 'Content-Type': 'application/x-www-form-urlencoded'};
 		if (isUpload) {


### PR DESCRIPTION
饭否最近全站升级 https 有一些问题, 
使用 http 协议访问会返回 302 , 
使用 https 协议访问会报签名异常, 原因是服务端签名中的 base_url 参数依旧采用的是 http 域名。

联系官方回复说打算修复, 这里先做一下兼容。